### PR TITLE
Improvements (prefixes, expose interface, warnings)

### DIFF
--- a/Classes/KZAsserts.h
+++ b/Classes/KZAsserts.h
@@ -17,6 +17,11 @@ extern const NSUInteger KZAssertFailedAssertionCode;
 typedef NSError *(*TKZAssertErrorFunction)(NSString *message, NSUInteger code, NSDictionary *userInfo);
 
 @interface KZAsserts : NSObject
+
+@property (nonatomic, class, readonly) NSString *kConditionKey;
+@property (nonatomic, class, readonly) NSString *kSourceKey;
+@property (nonatomic, class, readonly) NSString *kFunctionKey;
+
 + (void)registerErrorFunction:(TKZAssertErrorFunction)errorFunction;
 
 + (TKZAssertErrorFunction)errorFunction;
@@ -26,7 +31,16 @@ typedef NSError *(*TKZAssertErrorFunction)(NSString *message, NSUInteger code, N
 @end
 
 #ifndef KZAMakeError
-  #define KZAMakeError(message) KZAsserts.errorFunction([NSString stringWithFormat:@"Condition not satisfied: %@", message], KZAssertFailedAssertionCode, @{@"Source" : [NSString stringWithFormat:@"%s:%d", __FILE__, (int)__LINE__], @"Function" : @(__PRETTY_FUNCTION__)}); do{}while(0)
+  #define KZAMakeError(condition) \
+    KZAsserts.errorFunction( \
+      [NSString stringWithFormat:@"Condition not satisfied: %@", condition], \
+      KZAssertFailedAssertionCode, \
+      @{ \
+        KZAsserts.kConditionKey : condition, \
+        KZAsserts.kSourceKey : [NSString stringWithFormat:@"%s:%d", __FILE__, (int)__LINE__], \
+        KZAsserts.kFunctionKey : @(__PRETTY_FUNCTION__) \
+      } \
+    ); do{}while(0)
 #endif
 
 #define KZ_RED   @"\033[fg214,57,30;"

--- a/Classes/KZAsserts.h
+++ b/Classes/KZAsserts.h
@@ -100,4 +100,7 @@ do{} while(0)
 #define AssertTrueOrBreak(condition) AssertTrueOr(condition, break;)
 #define AssertTrueOrBreakBlock(condition, block) AssertTrueOr(condition, block(kza_error); break;)
 
+#define AssertTrueOrIgnore(condition) AssertTrueOr(condition, ;)
+#define AssertTrueOrIgnoreBlock(condition, block) AssertTrueOr(condition, block(kza_error);)
+
 #endif

--- a/Classes/KZAsserts.h
+++ b/Classes/KZAsserts.h
@@ -60,6 +60,7 @@ typedef NSError *(*TKZAssertErrorFunction)(NSString *message, NSUInteger code, N
 #define AssertTrueOr(condition, action) \
 _Pragma("clang diagnostic push") \
 _Pragma("clang diagnostic ignored \"-Wcstring-format-directive\"") \
+_Pragma("clang diagnostic ignored \"-Wnullable-to-nonnull-conversion\"") \
 { \
   BOOL evaluatedCondition = !!(condition); \
   if (KZDebugPassCondition(evaluatedCondition)) \

--- a/Classes/KZAsserts.h
+++ b/Classes/KZAsserts.h
@@ -29,10 +29,10 @@ typedef NSError *(*TKZAssertErrorFunction)(NSString *message, NSUInteger code, N
   #define KZAMakeError(message) KZAsserts.errorFunction([NSString stringWithFormat:@"Condition not satisfied: %@", message], KZAssertFailedAssertionCode, @{@"Source" : [NSString stringWithFormat:@"%s:%d", __FILE__, (int)__LINE__], @"Function" : @(__PRETTY_FUNCTION__)}); do{}while(0)
 #endif
 
-#define RED @"\033[fg214,57,30;"
-#define CLEAR "\033[fg;"
-#define BLUE @"\033[fg63,126,209;"
-#define GREEN @"\033[fg0,244,129;"
+#define KZ_RED   @"\033[fg214,57,30;"
+#define KZ_CLEAR  "\033[fg;"
+#define KZ_BLUE  @"\033[fg63,126,209;"
+#define KZ_GREEN @"\033[fg0,244,129;"
 
 #ifdef DEBUG
   #define KZDebugPassCondition(evaluatedCondition) (!evaluatedCondition && [KZAsserts debugPass:evaluatedCondition])
@@ -56,7 +56,7 @@ _Pragma("clang diagnostic ignored \"-Wcstring-format-directive\"") \
   } \
   else \
   { \
-    NSCAssert(evaluatedCondition, @"%@", [NSString stringWithFormat:RED @"KZAsserts" CLEAR BLUE @" %s" CLEAR @" @ " GREEN @"%s:%d" CLEAR RED @" | %@" CLEAR, __PRETTY_FUNCTION__, __FILE__, (int)__LINE__, @"Failed: " @#condition]); \
+    NSCAssert(evaluatedCondition, @"%@", [NSString stringWithFormat:KZ_RED @"KZAsserts" KZ_CLEAR KZ_BLUE @" %s" KZ_CLEAR @" @ " KZ_GREEN @"%s:%d" KZ_CLEAR KZ_RED @" | %@" KZ_CLEAR, __PRETTY_FUNCTION__, __FILE__, (int)__LINE__, @"Failed: " @#condition]); \
     if (!evaluatedCondition) \
     { \
       NSError *kza_error = KZAMakeError(@#condition); \

--- a/Classes/KZAsserts.m
+++ b/Classes/KZAsserts.m
@@ -16,7 +16,7 @@ NSError *kza_NSErrorMake(NSString *message, NSUInteger code, NSDictionary *aUser
   NSString *source = error.userInfo[@"Source"] ?: @"";
   NSString *function = error.userInfo[@"Function"] ?: @"";
 
-  printf("%s\n", [[NSString stringWithFormat: RED @"KZAsserts" CLEAR BLUE @" %@" CLEAR @" @ " GREEN @"%@" CLEAR RED @" | %@" CLEAR, function, source, message] UTF8String]);
+  printf("%s\n", [NSString stringWithFormat: KZ_RED @"KZAsserts" KZ_CLEAR KZ_BLUE @" %@" KZ_CLEAR @" @ " KZ_GREEN @"%@" KZ_CLEAR KZ_RED @" | %@" KZ_CLEAR, function, source, message].UTF8String);
   return error;
 }
 

--- a/Classes/KZAsserts.m
+++ b/Classes/KZAsserts.m
@@ -9,12 +9,16 @@
 
 const NSUInteger KZAssertFailedAssertionCode = 13143542;
 
+static NSString * const kKZAssertConditionKey = @"Condition";
+static NSString * const kKZAssertSourceKey = @"Source";
+static NSString * const kKZAssertFunctionKey = @"Function";
+
 NSError *kza_NSErrorMake(NSString *message, NSUInteger code, NSDictionary *aUserInfo) {
   NSMutableDictionary *userInfo = [aUserInfo mutableCopy];
   userInfo[NSLocalizedDescriptionKey] = message;
   NSError *error = [NSError errorWithDomain:@"info.merowing.internal" code:code userInfo:userInfo];
-  NSString *source = error.userInfo[@"Source"] ?: @"";
-  NSString *function = error.userInfo[@"Function"] ?: @"";
+  NSString *source = error.userInfo[kKZAssertSourceKey] ?: @"";
+  NSString *function = error.userInfo[kKZAssertFunctionKey] ?: @"";
 
   printf("%s\n", [NSString stringWithFormat: KZ_RED @"KZAsserts" KZ_CLEAR KZ_BLUE @" %@" KZ_CLEAR @" @ " KZ_GREEN @"%@" KZ_CLEAR KZ_RED @" | %@" KZ_CLEAR, function, source, message].UTF8String);
   return error;
@@ -23,6 +27,21 @@ NSError *kza_NSErrorMake(NSString *message, NSUInteger code, NSDictionary *aUser
 static TKZAssertErrorFunction function = NULL;
 
 @implementation KZAsserts
+
++ (NSString *)kConditionKey
+{
+  return kKZAssertConditionKey;
+}
+
++ (NSString *)kSourceKey
+{
+  return kKZAssertSourceKey;
+}
+
++ (NSString *)kFunctionKey
+{
+  return kKZAssertFunctionKey;
+}
 
 + (void)registerErrorFunction:(TKZAssertErrorFunction)errorFunction
 {

--- a/KZAsserts.podspec
+++ b/KZAsserts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KZAsserts"
-  s.version          = "1.1.0"
+  s.version          = "1.2.0"
   s.summary          = "KZAsserts is set of expanded assert macros that don't crash on release builds and support asynchronus code execution."
   s.description      = <<-DESC
                        KZAsserts has been created to allow developers to assert assumptions without worrying about crashing client facing versions of the app, it simplifies error handling by supporting asynchronus code execution and automatic error generation.

--- a/KZAsserts.podspec
+++ b/KZAsserts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "KZAsserts"
-  s.version          = "1.2.0"
+  s.version          = "1.2.1"
   s.summary          = "KZAsserts is set of expanded assert macros that don't crash on release builds and support asynchronus code execution."
   s.description      = <<-DESC
                        KZAsserts has been created to allow developers to assert assumptions without worrying about crashing client facing versions of the app, it simplifies error handling by supporting asynchronus code execution and automatic error generation.

--- a/KZAsserts.podspec
+++ b/KZAsserts.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/krzysztofzablocki/KZAsserts.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/merowing_'
 
-  s.platform     = :ios, '4.0'
-  s.ios.deployment_target = '4.0'
+  s.platform     = :ios, '6.0'
+  s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.7'
   s.tvos.deployment_target = '9.0'
   s.requires_arc = true

--- a/README.md
+++ b/README.md
@@ -84,11 +84,14 @@ KZAsserts provies following asserts:
   AssertTrueOrBreak
   AssertTrueOrBreakBlock
 
+  AssertTrueOrIgnore
+  AssertTrueOrIgnoreBlock
+
 ````
 
 ## Installation
 
-KZAsserts is available through [CocoaPods](http://cocoapods.org) for OSX, iOS and tvOS, to install
+KZAsserts is available through [CocoaPods](http://cocoapods.org) for macOS, iOS and tvOS, to install
 it simply add the following line to your Podfile:
 
     pod "KZAsserts"


### PR DESCRIPTION
* Added `KZ_` prefix to colors defines.
* KZAssert.podspec update deployment_target to **6.0** because are warning:
    `setObject:forKeyedSubscript:` is only available on iOS 6.0 or newer.
* Add two defines: AssertTrueOrIgnore and AssertTrueOrIgnoreBlock.
* Added public access to userInfo keys and add 'Condition' key. Expand define KZAMakeError.
* Update KZAssert.podspec. Bump version to 1.2.0.
* Update README.md.
